### PR TITLE
update battery related readings also if unchanged

### DIFF
--- a/FHEM/70_INDEGO.pm
+++ b/FHEM/70_INDEGO.pm
@@ -876,9 +876,9 @@ sub ReceiveCommand {
           if ( ref($return) eq "HASH") {
             if ( ref($return->{battery}) eq "HASH" ) {
               my $battery = $return->{battery};
-              readingsBulkUpdateIfChanged($hash, "battery",         $battery->{percent});
-              readingsBulkUpdateIfChanged($hash, "battery_temp",    $battery->{battery_temp});
-              readingsBulkUpdateIfChanged($hash, "battery_voltage", $battery->{voltage});
+              readingsBulkUpdate($hash, "battery",         $battery->{percent});
+              readingsBulkUpdate($hash, "battery_temp",    $battery->{battery_temp});
+              readingsBulkUpdate($hash, "battery_voltage", $battery->{voltage});
             }
             if ( ref($return->{garden}) eq "HASH" ) {
               my $garden = $return->{garden};


### PR DESCRIPTION
Proposal: update battery related readings also if unchanged

Behavior before change: readingsBulkUpdate**IfChanged**(...)
Behavior after change: readingsBulkUpdate(...)

Reasoning: Updates of battery readings are triggered by a "set MyIndego operatingData" command. The response is coming in an asynchronous fashion some time later, so there is no chance to react to the result of the command if there is no event for unchanged readings. E.g. that helps improving the timing accuracy for plotting a battery curve, see attached plot. The areas marked with yellow marker should instead see a horizontal battery line (dark red) until charging starts (charging curve in light red). For that plot operatingData is requested on each major state change and only every 3 hours inbetween.

![plot](https://user-images.githubusercontent.com/23030379/174132994-10fb237d-d418-4aec-b82b-97cee94b7292.png)
